### PR TITLE
Fix missing build dependencies for GTK4

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,7 +9,8 @@
       "Bash(desktop-file-validate:*)",
       "Bash(gh run list:*)",
       "WebSearch",
-      "Bash(git add:*)"
+      "Bash(git add:*)",
+      "Bash(pkg-config:*)"
     ],
     "deny": [],
     "ask": []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [0.2.16] - 2025-10-22
 
+### Fixed
+- **Build Dependencies**: Added explicit build dependencies for gdk-pixbuf and graphene
+  - Updated Makefile.toml with complete dependency installation for all supported distributions
+  - Updated INSTALL.md with comprehensive build dependency documentation
+  - Fixed missing pkg-config files (gdk-pixbuf-2.0.pc, graphene-gobject-1.0.pc) that caused build failures on fresh systems
+  - Debian/Ubuntu: Now explicitly installs `libgdk-pixbuf-2.0-dev` and `libgraphene-1.0-dev`
+  - Arch Linux: Now explicitly installs `gdk-pixbuf2` and `graphene`
+  - Solus: Now explicitly installs `gdk-pixbuf-devel` and `graphene-devel`
+  - Fedora/RHEL: Now explicitly installs `gdk-pixbuf2-devel` and `graphene-devel`
+
 ## [0.2.15] - 2025-10-22
 
 ## [0.2.14] - 2025-03-17

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "fin"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "clap",

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,15 +32,21 @@ Finë requires the following runtime dependencies to be installed on your system
 ### Build Dependencies (Only for manual compilation)
 
 - **Rust** (>= 1.70): Install via [rustup](https://rustup.rs/)
-- **GTK4 development files**:
-  - Debian/Ubuntu: `libgtk-4-dev`
-  - Arch Linux: `gtk4` (includes development files)
-  - Solus: `gtk4-devel`
-  - Fedora/RHEL: `gtk4-devel`
+- **GTK4 and related development files**:
+  - Debian/Ubuntu: `libgtk-4-dev`, `libgdk-pixbuf-2.0-dev`, `libgraphene-1.0-dev`
+  - Arch Linux: `gtk4`, `gdk-pixbuf2`, `graphene` (includes development files)
+  - Solus: `gtk4-devel`, `gdk-pixbuf-devel`, `graphene-devel`
+  - Fedora/RHEL: `gtk4-devel`, `gdk-pixbuf2-devel`, `graphene-devel`
 - **pkg-config**: Build tool for finding libraries
   - Debian/Ubuntu: `pkg-config`
   - Arch Linux: `pkgconf`
   - Solus: `pkgconfig`
+  - Fedora/RHEL: `pkg-config`
+- **Build essentials**: Compiler and build tools
+  - Debian/Ubuntu: `build-essential`
+  - Arch Linux: `base-devel`
+  - Solus: included in system-devel component
+  - Fedora/RHEL: `gcc`
 - **cargo-make**: Rust task runner (optional, for using `cargo make install`)
   - Install via: `cargo install cargo-make`
 
@@ -110,23 +116,23 @@ First, install the required dependencies for your distribution:
 **Debian/Ubuntu:**
 ```sh
 sudo apt-get update
-sudo apt-get install -y libgtk-4-dev pkg-config build-essential
+sudo apt-get install -y libgtk-4-dev libgdk-pixbuf-2.0-dev libgraphene-1.0-dev pkg-config build-essential
 ```
 
 **Arch Linux:**
 ```sh
-sudo pacman -Syu --noconfirm gtk4 base-devel pkgconf
+sudo pacman -Syu --noconfirm gtk4 gdk-pixbuf2 graphene base-devel pkgconf
 ```
 
 **Solus:**
 ```sh
 sudo eopkg up
-sudo eopkg install -y gtk4-devel
+sudo eopkg install -y gtk4-devel gdk-pixbuf-devel graphene-devel
 ```
 
 **Fedora/RHEL:**
 ```sh
-sudo dnf install -y gtk4-devel pkg-config gcc
+sudo dnf install -y gtk4-devel gdk-pixbuf2-devel graphene-devel pkg-config gcc
 ```
 
 #### 2. Install Rust (if not already installed)

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -57,26 +57,26 @@ script = [
 description = "Install dependencies on Ubuntu"
 script = [
     "sudo apt-get update",
-    "sudo apt-get install -y libgtk-4-dev pkg-config build-essential"
+    "sudo apt-get install -y libgtk-4-dev libgdk-pixbuf-2.0-dev libgraphene-1.0-dev pkg-config build-essential"
 ]
 
 [tasks.install-dependencies-arch]
 description = "Install dependencies on Arch Linux"
 script = [
-    "sudo pacman -Syu --noconfirm gtk4 base-devel pkgconf"
+    "sudo pacman -Syu --noconfirm gtk4 gdk-pixbuf2 graphene base-devel pkgconf"
 ]
 
 [tasks.install-dependencies-solus]
 description = "Install dependencies on Solus"
 script = [
     "sudo eopkg up",
-    "sudo eopkg install -y gtk4-devel"
+    "sudo eopkg install -y gtk4-devel gdk-pixbuf-devel graphene-devel"
 ]
 
 [tasks.install-dependencies-fedora]
 description = "Install dependencies on Fedora/RHEL"
 script = [
-    "sudo dnf install -y gtk4-devel pkg-config gcc"
+    "sudo dnf install -y gtk4-devel gdk-pixbuf2-devel graphene-devel pkg-config gcc"
 ]
 
 [tasks.install-dependencies]


### PR DESCRIPTION
## Summary
Fixes critical build failures on fresh systems by adding missing build dependencies for gdk-pixbuf and graphene libraries.

## Problem
Building from source on fresh systems was failing with missing pkg-config files:
- `gdk-pixbuf-2.0.pc`
- `graphene-gobject-1.0.pc`

## Solution
Added explicit build dependencies to all supported distributions:

### Updated Files
- **Makefile.toml**: Added `libgdk-pixbuf-2.0-dev` and `libgraphene-1.0-dev` (and distro equivalents) to dependency install tasks
- **INSTALL.md**: Documented complete build dependencies with explicit package names for all distributions
- **CHANGELOG.md**: Documented the fix for version 0.2.16

### Verified Working On
✅ **Debian/Ubuntu**: `libgtk-4-dev libgdk-pixbuf-2.0-dev libgraphene-1.0-dev pkg-config build-essential`
✅ **Arch Linux**: `gtk4 gdk-pixbuf2 graphene base-devel pkgconf`
✅ **Fedora/RHEL**: `gtk4-devel gdk-pixbuf2-devel graphene-devel pkg-config gcc`

All three distributions tested in clean Docker containers - all required pkg-config files now found.

## Test Plan
- [x] Updated dependency documentation for all supported distros
- [x] Verified Debian/Ubuntu dependencies in clean Docker container
- [x] Verified Arch Linux dependencies in clean Docker container  
- [x] Verified Fedora dependencies in clean Docker container
- [x] All quality checks passed (fmt, clippy, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)