### PR TITLE
Fix build dependencies for GTK4 compilation

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,13 @@
       "Bash(gh run list:*)",
       "WebSearch",
       "Bash(git add:*)",
-      "Bash(pkg-config:*)"
+      "Bash(pkg-config:*)",
+      "Bash(docker run:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr close:*)",
+      "Bash(docker build:*)",
+      "Bash(docker search:*)",
+      "Bash(git commit:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,7 +9,8 @@
       "Bash(desktop-file-validate:*)",
       "Bash(gh run list:*)",
       "WebSearch",
-      "Bash(git add:*)"
+      "Bash(git add:*)",
+      "Bash(pkg-config:*)"
     ],
     "deny": [],
     "ask": []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [0.2.16] - 2025-10-22
 
+### Fixed
+- **Build Dependencies**: Added explicit build dependencies for gdk-pixbuf and graphene
+  - Updated Makefile.toml with complete dependency installation for all supported distributions
+  - Updated INSTALL.md with comprehensive build dependency documentation
+  - Fixed missing pkg-config files (gdk-pixbuf-2.0.pc, graphene-gobject-1.0.pc) that caused build failures on fresh systems
+  - Debian/Ubuntu: Now explicitly installs `libgdk-pixbuf-2.0-dev` and `libgraphene-1.0-dev`
+  - Arch Linux: Now explicitly installs `gdk-pixbuf2` and `graphene`
+  - Solus: Now explicitly installs `gdk-pixbuf-devel` and `graphene-devel`
+  - Fedora/RHEL: Now explicitly installs `gdk-pixbuf2-devel` and `graphene-devel`
+
 ## [0.2.15] - 2025-10-22
 
 ## [0.2.14] - 2025-03-17

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "fin"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "clap",

--- a/Dockerfile.solus
+++ b/Dockerfile.solus
@@ -1,0 +1,9 @@
+FROM gzgavinzhao/solus:latest
+
+# Update repository
+RUN eopkg update-repo
+
+# Install required packages (no system upgrade needed if image is recent)
+RUN eopkg install -y pkg-config libgtk-4-devel gdk-pixbuf-devel graphene-devel gcc make
+
+CMD ["/bin/bash"]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -35,8 +35,9 @@ Finë requires the following runtime dependencies to be installed on your system
 - **GTK4 and related development files**:
   - Debian/Ubuntu: `libgtk-4-dev`, `libgdk-pixbuf-2.0-dev`, `libgraphene-1.0-dev`
   - Arch Linux: `gtk4`, `gdk-pixbuf2`, `graphene` (includes development files)
-  - Solus: `gtk4-devel`, `gdk-pixbuf-devel`, `graphene-devel`
+  - Solus: `libgtk-4-devel`, `gdk-pixbuf-devel`, `graphene-devel`
   - Fedora/RHEL: `gtk4-devel`, `gdk-pixbuf2-devel`, `graphene-devel`
+  - NixOS: `gtk4`, `gdk-pixbuf`, `graphene`, `glib.dev`
 - **pkg-config**: Build tool for finding libraries
   - Debian/Ubuntu: `pkg-config`
   - Arch Linux: `pkgconf`
@@ -45,7 +46,7 @@ Finë requires the following runtime dependencies to be installed on your system
 - **Build essentials**: Compiler and build tools
   - Debian/Ubuntu: `build-essential`
   - Arch Linux: `base-devel`
-  - Solus: included in system-devel component
+  - Solus: `system.devel`
   - Fedora/RHEL: `gcc`
 - **cargo-make**: Rust task runner (optional, for using `cargo make install`)
   - Install via: `cargo install cargo-make`
@@ -127,12 +128,17 @@ sudo pacman -Syu --noconfirm gtk4 gdk-pixbuf2 graphene base-devel pkgconf
 **Solus:**
 ```sh
 sudo eopkg up
-sudo eopkg install -y gtk4-devel gdk-pixbuf-devel graphene-devel
+sudo eopkg install -y libgtk-4-devel gdk-pixbuf-devel graphene-devel
 ```
 
 **Fedora/RHEL:**
 ```sh
 sudo dnf install -y gtk4-devel gdk-pixbuf2-devel graphene-devel pkg-config gcc
+```
+
+**NixOS:**
+```sh
+nix-env -iA nixpkgs.gtk4 nixpkgs.gdk-pixbuf nixpkgs.graphene nixpkgs.glib.dev nixpkgs.pkg-config nixpkgs.gcc
 ```
 
 #### 2. Install Rust (if not already installed)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -46,7 +46,7 @@ Finë requires the following runtime dependencies to be installed on your system
 - **Build essentials**: Compiler and build tools
   - Debian/Ubuntu: `build-essential`
   - Arch Linux: `base-devel`
-  - Solus: `system.devel`
+  - Solus: `gcc`, `make`, `pkgconf`
   - Fedora/RHEL: `gcc`
 - **cargo-make**: Rust task runner (optional, for using `cargo make install`)
   - Install via: `cargo install cargo-make`

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,12 +41,12 @@ Finë requires the following runtime dependencies to be installed on your system
 - **pkg-config**: Build tool for finding libraries
   - Debian/Ubuntu: `pkg-config`
   - Arch Linux: `pkgconf`
-  - Solus: `pkgconfig`
+  - Solus: `pkg-config`
   - Fedora/RHEL: `pkg-config`
 - **Build essentials**: Compiler and build tools
   - Debian/Ubuntu: `build-essential`
   - Arch Linux: `base-devel`
-  - Solus: `gcc`, `make`, `pkgconf`
+  - Solus: `gcc`, `make`, `pkg-config`
   - Fedora/RHEL: `gcc`
 - **cargo-make**: Rust task runner (optional, for using `cargo make install`)
   - Install via: `cargo install cargo-make`
@@ -128,7 +128,7 @@ sudo pacman -Syu --noconfirm gtk4 gdk-pixbuf2 graphene base-devel pkgconf
 **Solus:**
 ```sh
 sudo eopkg up
-sudo eopkg install -y pkgconf libgtk-4-devel gdk-pixbuf-devel graphene-devel gcc make
+sudo eopkg install -y pkg-config libgtk-4-devel gdk-pixbuf-devel graphene-devel gcc make
 ```
 
 **Fedora/RHEL:**

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,15 +32,21 @@ Finë requires the following runtime dependencies to be installed on your system
 ### Build Dependencies (Only for manual compilation)
 
 - **Rust** (>= 1.70): Install via [rustup](https://rustup.rs/)
-- **GTK4 development files**:
-  - Debian/Ubuntu: `libgtk-4-dev`
-  - Arch Linux: `gtk4` (includes development files)
-  - Solus: `gtk4-devel`
-  - Fedora/RHEL: `gtk4-devel`
+- **GTK4 and related development files**:
+  - Debian/Ubuntu: `libgtk-4-dev`, `libgdk-pixbuf-2.0-dev`, `libgraphene-1.0-dev`
+  - Arch Linux: `gtk4`, `gdk-pixbuf2`, `graphene` (includes development files)
+  - Solus: `gtk4-devel`, `gdk-pixbuf-devel`, `graphene-devel`
+  - Fedora/RHEL: `gtk4-devel`, `gdk-pixbuf2-devel`, `graphene-devel`
 - **pkg-config**: Build tool for finding libraries
   - Debian/Ubuntu: `pkg-config`
   - Arch Linux: `pkgconf`
   - Solus: `pkgconfig`
+  - Fedora/RHEL: `pkg-config`
+- **Build essentials**: Compiler and build tools
+  - Debian/Ubuntu: `build-essential`
+  - Arch Linux: `base-devel`
+  - Solus: included in system-devel component
+  - Fedora/RHEL: `gcc`
 - **cargo-make**: Rust task runner (optional, for using `cargo make install`)
   - Install via: `cargo install cargo-make`
 
@@ -110,23 +116,23 @@ First, install the required dependencies for your distribution:
 **Debian/Ubuntu:**
 ```sh
 sudo apt-get update
-sudo apt-get install -y libgtk-4-dev pkg-config build-essential
+sudo apt-get install -y libgtk-4-dev libgdk-pixbuf-2.0-dev libgraphene-1.0-dev pkg-config build-essential
 ```
 
 **Arch Linux:**
 ```sh
-sudo pacman -Syu --noconfirm gtk4 base-devel pkgconf
+sudo pacman -Syu --noconfirm gtk4 gdk-pixbuf2 graphene base-devel pkgconf
 ```
 
 **Solus:**
 ```sh
 sudo eopkg up
-sudo eopkg install -y gtk4-devel
+sudo eopkg install -y gtk4-devel gdk-pixbuf-devel graphene-devel
 ```
 
 **Fedora/RHEL:**
 ```sh
-sudo dnf install -y gtk4-devel pkg-config gcc
+sudo dnf install -y gtk4-devel gdk-pixbuf2-devel graphene-devel pkg-config gcc
 ```
 
 #### 2. Install Rust (if not already installed)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -128,7 +128,7 @@ sudo pacman -Syu --noconfirm gtk4 gdk-pixbuf2 graphene base-devel pkgconf
 **Solus:**
 ```sh
 sudo eopkg up
-sudo eopkg install -y libgtk-4-devel gdk-pixbuf-devel graphene-devel
+sudo eopkg install -y pkgconf libgtk-4-devel gdk-pixbuf-devel graphene-devel gcc make
 ```
 
 **Fedora/RHEL:**

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -70,7 +70,7 @@ script = [
 description = "Install dependencies on Solus"
 script = [
     "sudo eopkg up",
-    "sudo eopkg install -y pkgconf libgtk-4-devel gdk-pixbuf-devel graphene-devel gcc make"
+    "sudo eopkg install -y pkg-config libgtk-4-devel gdk-pixbuf-devel graphene-devel gcc make"
 ]
 
 [tasks.install-dependencies-fedora]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -70,7 +70,7 @@ script = [
 description = "Install dependencies on Solus"
 script = [
     "sudo eopkg up",
-    "sudo eopkg install -y gtk4-devel gdk-pixbuf-devel graphene-devel"
+    "sudo eopkg install -y system.devel libgtk-4-devel gdk-pixbuf-devel graphene-devel"
 ]
 
 [tasks.install-dependencies-fedora]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -70,7 +70,7 @@ script = [
 description = "Install dependencies on Solus"
 script = [
     "sudo eopkg up",
-    "sudo eopkg install -y system.devel libgtk-4-devel gdk-pixbuf-devel graphene-devel"
+    "sudo eopkg install -y pkgconf libgtk-4-devel gdk-pixbuf-devel graphene-devel gcc make"
 ]
 
 [tasks.install-dependencies-fedora]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -57,26 +57,26 @@ script = [
 description = "Install dependencies on Ubuntu"
 script = [
     "sudo apt-get update",
-    "sudo apt-get install -y libgtk-4-dev pkg-config build-essential"
+    "sudo apt-get install -y libgtk-4-dev libgdk-pixbuf-2.0-dev libgraphene-1.0-dev pkg-config build-essential"
 ]
 
 [tasks.install-dependencies-arch]
 description = "Install dependencies on Arch Linux"
 script = [
-    "sudo pacman -Syu --noconfirm gtk4 base-devel pkgconf"
+    "sudo pacman -Syu --noconfirm gtk4 gdk-pixbuf2 graphene base-devel pkgconf"
 ]
 
 [tasks.install-dependencies-solus]
 description = "Install dependencies on Solus"
 script = [
     "sudo eopkg up",
-    "sudo eopkg install -y gtk4-devel"
+    "sudo eopkg install -y gtk4-devel gdk-pixbuf-devel graphene-devel"
 ]
 
 [tasks.install-dependencies-fedora]
 description = "Install dependencies on Fedora/RHEL"
 script = [
-    "sudo dnf install -y gtk4-devel pkg-config gcc"
+    "sudo dnf install -y gtk4-devel gdk-pixbuf2-devel graphene-devel pkg-config gcc"
 ]
 
 [tasks.install-dependencies]


### PR DESCRIPTION
## Summary
- Fixed missing build dependencies that caused compilation failures on fresh systems
- Added explicit dependencies for `gdk-pixbuf` and `graphene` libraries across all supported distributions
- Updated `Makefile.toml` with complete dependency installation tasks
- Updated `INSTALL.md` with comprehensive build dependency documentation
- Docker tested all distributions to verify dependencies are complete and correct

## Changes
- **Debian/Ubuntu**: Added `libgdk-pixbuf-2.0-dev` and `libgraphene-1.0-dev`
- **Arch Linux**: Added `gdk-pixbuf2` and `graphene`
- **Solus**: Added `gdk-pixbuf-devel`, `graphene-devel`, and corrected `pkg-config` package name
- **Fedora/RHEL**: Added `gdk-pixbuf2-devel` and `graphene-devel`
- **NixOS**: Added `gdk-pixbuf`, `graphene`, and `glib.dev`

## Testing
All distributions verified with full builds in clean Docker containers:
- ✅ Debian/Ubuntu (debian:bookworm)
- ✅ Arch Linux (archlinux:latest)
- ✅ Fedora (fedora:latest)
- ✅ NixOS (nixos/nix)
- ✅ Solus (gzgavinzhao/solus:latest)

## Fixes
- Resolves build failures with missing pkg-config files (`gdk-pixbuf-2.0.pc`, `graphene-gobject-1.0.pc`)
- Ensures users can build from source on fresh system installations