### PR TITLE
Fix git ref ambiguity in trunk push

### DIFF
--- a/scripts/bump-and-release.sh
+++ b/scripts/bump-and-release.sh
@@ -55,7 +55,7 @@ git config user.name "CI Bot"
 # Commit version bump directly to trunk
 git add Cargo.toml PKGBUILD fin.sol flake.nix INSTALL.md CHANGELOG.md Cargo.lock
 git commit -m "Bump version to $new_version"
-git push origin trunk
+git push origin HEAD:refs/heads/trunk
 
 echo "✅ Version bumped to $new_version and pushed to trunk"
 


### PR DESCRIPTION
## Summary
Fixes the git ref ambiguity error that's causing the bump_and_release job to fail.

## Problem
The current script uses `git push origin trunk` which is ambiguous when both a branch and tag named "trunk" exist, causing:
```
error: src refspec trunk matches more than one
```

## Solution
Use explicit ref path `git push origin HEAD:refs/heads/trunk` to unambiguously target the trunk branch.

## Test plan
- Merge this PR to trunk
- Workflow should complete successfully without ref ambiguity errors